### PR TITLE
Containerize unit tests and include them as part of the build push workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Run tests
+        run: make test
+
       - name: Log in to Quay.io
         uses: redhat-actions/podman-login@v1
         with:

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,37 @@
+# Test Dockerfile following ros-ocp-backend patterns
+# Single-stage build for running tests in containerized environment
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24
+
+WORKDIR /go/src/app
+COPY . .
+
+# Switch to root to install dependencies and run tests
+USER 0
+
+# Install golangci-lint for linting tests
+
+# Add Go bin to PATH
+ENV PATH="$PATH:$(go env GOPATH)/bin"
+
+# Set Go flags to use mod mode
+ENV GOFLAGS="-v -race -mod=mod -coverprofile=coverage.out"
+
+# Create test output directory and mock directories
+RUN mkdir -p /tmp/test-results internal/auth/mocks
+
+# Generate mocks if needed and run tests
+RUN echo "Ensuring mocks exist..." && \
+    if [ ! -f internal/auth/mocks/mock_k8s_auth.go ]; then \
+        echo "Generating mocks with go generate..." && \
+        cd internal/auth/ && \
+        go generate ./generate.go || \
+        echo "Mocks already present or generation failed - using existing mocks"; \
+    fi && \
+    echo "Mocks ready in internal/auth/mocks/"
+
+# Run tests during build - build will fail if tests fail
+RUN set -e && \
+    echo "Running tests..." && \
+    go test ${GOFLAGS} ./... || (echo "❌ TESTS FAILED - Build stopped" && exit 1)
+
+

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,18 @@ vet: ## Run go vet
 	go vet ./...
 
 .PHONY: test
-test: mocks ## Run tests
-	@echo "Running tests..."
+test: ## Run tests in containerized environment
+	@echo "Running tests in containerized environment..."
+	podman build -f Dockerfile.tests -t $(APP_NAME):test .
+	@echo "✅ All tests passed in container!"
+
+.PHONY: test-local
+test-local: mocks ## Run tests locally (without container)
+	@echo "Running tests locally..."
 	go test -v -race -coverprofile=coverage.out ./...
 
 .PHONY: test-coverage
-test-coverage: test ## Run tests and generate coverage report
+test-coverage: test-local ## Run tests locally and generate coverage report
 	@echo "Generating coverage report..."
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"


### PR DESCRIPTION
* Adds the make test to the buid-and-push.yml workflow to ensure all tests are passing before building and pushing the image
* Run the unit tests in a container using podman

Signed-off-by: Jordi Gil <jgil@redhat.com>
