### PR TITLE
Fix Dockerfile.tests syntax error causing build failures

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -33,5 +33,5 @@ RUN echo "Ensuring mocks exist..." && \
 RUN set -e && \
     echo "Running tests..." && \
     go test ${GOFLAGS} ./... || (echo "❌ TESTS FAILED - Build stopped" && exit 1)
-
+RUN echo "✅ TESTS PASSED - Build completed"
 

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ vet: ## Run go vet
 .PHONY: test
 test: ## Run tests in containerized environment
 	@echo "Running tests in containerized environment..."
-	podman build -f Dockerfile.tests -t $(APP_NAME):test .
-	@echo "✅ All tests passed in container!"
+	podman build --no-cache -f Dockerfile.tests -t $(APP_NAME):test .
 
 .PHONY: test-local
 test-local: mocks ## Run tests locally (without container)


### PR DESCRIPTION
* Add `--no-cache` to podman when running the tests to ensure it does not use cached layers and runs all the tests