### PR TITLE
Fix Makefile build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,7 @@ mocks: install-tools ## Generate mocks for testing
 	@if [ ! -f internal/auth/mocks/mock_k8s_auth.go ]; then \
 		echo "Generating mocks with go generate..."; \
 		cd internal/auth/ && \
-		GOFLAGS=-mod=mod go generate ./generate.go || \
-		echo "Mocks already present or generation failed - using existing mocks"; \
+		GOFLAGS=-mod=mod go generate ./generate.go; \
 	fi
 	@echo "Mocks ready in internal/auth/mocks/"
 

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ install-tools: ## Install required development tools
 	@echo "Installing development tools..."
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo "Installing golangci-lint..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin latest; \
 	}
 	@command -v goimports >/dev/null 2>&1 || { \
 		echo "Installing goimports..."; \


### PR DESCRIPTION
Fix two issues that prevented builds from working correctly on remote servers.

First, the install-tools target was trying to install `golangci-lint` to /bin instead of the user's `GOPATH` because `Make` was evaluating the command substitution instead of the shell.

Second, mock generation failures were being silently ignored, which caused `go mod tidy` to think the mocks package was external and try fetching it from GitHub. This resulted in confusing authentication errors instead of clear `mockgen not found` messages.

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>